### PR TITLE
slf4j-simple should not include to parsec base build since it's a binding implement

### DIFF
--- a/parsec-base-build/src/main/resources/parsec.gradle
+++ b/parsec-base-build/src/main/resources/parsec.gradle
@@ -89,7 +89,6 @@ dependencies {
     compile group: 'org.glassfish.jersey.inject'    , name: 'jersey-hk2'                  , version: jerseyVersion
     compile group: 'org.eclipse.jetty'              , name: 'jetty-servlet'               , version: jettyVersion
     compile group: 'org.slf4j'                      , name: 'slf4j-api'                   , version: slf4jVersion
-    compile group: 'org.slf4j'                      , name: 'slf4j-simple'                , version: slf4jVersion
     providedCompile group: 'javax.servlet'          , name: 'servlet-api'                 , version: servletApiVersion
 
     //Java 11 compatible


### PR DESCRIPTION



<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
