### PR TITLE
make preTestBuild wait time longer

### DIFF
--- a/parsec-integration-test/build.gradle
+++ b/parsec-integration-test/build.gradle
@@ -69,12 +69,13 @@ task preTestBuild {
         def process = new ProcessBuilder(command).directory(projectDir).redirectErrorStream(true).start()
         def sout = new StringBuilder(), serr = new StringBuilder()
         process.consumeProcessOutput(sout, serr)
-        process.waitForOrKill(120000) //Wait for 2 mins or kill process regardless
+        process.waitForOrKill(600000) //Wait for 10 mins or kill process regardless
         println sout
-        if(process.exitValue() == 0){
+        def exitValue = process.exitValue()
+        if(exitValue == 0){
             process.destroy() //Note that Jetty is still running at this point
         } else {
-            throw new GradleException("Starting jetty fail")
+            throw new GradleException("Starting jetty fail. Process exit value: " + exitValue)
         }
     }
 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

From the last master build, the `preTestBuild` step in `parsec-integration-test:build.gradle` seems taking longer time than before, which makes it violates the timeout and will be killed halfway. Hence a longer timeout might be needed.